### PR TITLE
dont raise on 500s

### DIFF
--- a/node-placeholder-scaler/scaler/calendar.py
+++ b/node-placeholder-scaler/scaler/calendar.py
@@ -57,7 +57,12 @@ def get_calendar(url: str):
             calendar = IcsCalendarStream.calendar_from_ics(f.read())
     else:
         r = requests.get(url)
-        r.raise_for_status()
+        if r.status_code == 500:
+            logging.info(f"Received intermittent 500 error from: {url}")
+            return None
+        else:
+            r.raise_for_status()
+
         calendar = IcsCalendarStream.calendar_from_ics(r.text)
 
     if calendar:


### PR DESCRIPTION
this supersedes https://github.com/cal-icor/jupyterhub-k8s-node-placeholder/pull/13

sometimes `ical` is unable to reach the public calendar, and this results in a cascading (but very brief) failure:

```
niquests.exceptions.HTTPError: 500 Server Error: Internal Server Error for url: https://calendar.google.com/calendar/ical/c_35d90f50598c1472a4154c538bb49a21eabd8be93831d7de345d53fea8e19390%40group.calendar.google.com/public/basic.ics
```

after this happens, `niquests.get_url()` throws the above with the `requests.raise_for_status()` call and emits the following bit in to the logs:

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/srv/scaler/__main__.py", line 4, in <module>
    main()
  File "/srv/scaler/scaler.py", line 86, in main
    calendar = get_calendar(config["calendarUrl"])
```

after this, the `node-placeholder-scaler` pod crashes, and immediately restarts (cascading failures but ultimately benign and self-healing.  yay k8s!).

however, there are GCP alerts set up to scan the calendar entries for HTML (meaning someone formatted text in the scaler event description).  this check simply looks for `<` or `>`, and the `<frozen runpy>` error matches this (natch!).  

this change was proposed by @ryanlovett in the aforementioned PR at the top of this desc, but due to git silliness his PR touches more than it should.