### PR TITLE
allow custom configuration of the timezone

### DIFF
--- a/helm/node-placeholder/templates/deployment.yaml
+++ b/helm/node-placeholder/templates/deployment.yaml
@@ -38,6 +38,9 @@ spec:
           args:
             - --config-file=/etc/scaler/config.yaml
             - --placeholder-template-file=/etc/scaler/placeholder-template.yaml
+          env:
+            - name: TZ
+              value: {{ .Values.calendarTimezone | default "UTC" }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/helm/node-placeholder/values.yaml
+++ b/helm/node-placeholder/values.yaml
@@ -49,9 +49,15 @@ priorityClass:
 
 tolerations:
 
-# The URL of the public calendar to use for the node placeholder
+# The URL of the public calendar to use for the node placeholder.
 # calendarUrl:
-
+#   https://url/of/the/public/calendar.ics
+#
+# This should be the timezone of the calendar. This is to normalize all day
+# events, which don't have a timezone. If this is not set, the default timezone
+# for all day events will be UTC, and not the timezone of the calendar.
+# If not set, defaults to UTC
+# calendarTimezone: "America/Los_Angeles"
 
 # Calculate size of node placeholder by:
 # 1. Select a node in the node pool you want to configure

--- a/node-placeholder-scaler/Dockerfile
+++ b/node-placeholder-scaler/Dockerfile
@@ -1,9 +1,5 @@
 FROM python:3.11
 
-# This is to normalize all day events, which don't have a timezone.
-ENV TZ=America/Los_Angeles
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-
 ENV KUBECTL_VERSION v1.33.1
 ADD https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl /usr/local/bin/kubectl
 RUN chmod +x /usr/local/bin/kubectl


### PR DESCRIPTION
instead of specifying the TZ in the `Dockerfile`, allow end users to configure this in their own `values.yaml`.

resolves https://github.com/cal-icor/jupyterhub-k8s-node-placeholder/issues/7